### PR TITLE
chore(types): generate declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.14.7",
   "description": "",
   "main": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
   "bin": {
     "build": "./dist/bin/build.js",
     "run": "./dist/bin/run.js"
@@ -11,7 +12,7 @@
     "prepublish": "npm run build",
     "test": "npm run build && ava",
     "coverage": "nyc ava",
-    "build": "tsc",
+    "build": "tsc --declaration",
     "release": "npm test && standard-version"
   },
   "repository": {

--- a/src/lib/Builder.ts
+++ b/src/lib/Builder.ts
@@ -17,14 +17,14 @@ import { NsisVersionInfo } from './common';
 import { NsisComposer, NsisDiffer, Nsis7Zipper, nsisBuild } from './nsis-gen';
 import { mergeOptions, findExecutable, findFFmpeg, findRuntimeRoot, findExcludableDependencies, tmpName, tmpFile, tmpDir, fixWindowsVersion, copyFileAsync, extractGeneric, compress } from './util';
 
-interface IParseOutputPatternOptions {
+export interface IParseOutputPatternOptions {
     name: string;
     version: string;
     platform: string;
     arch: string;
 }
 
-interface IBuilderOptions {
+export interface IBuilderOptions {
     win?: boolean;
     mac?: boolean;
     linux?: boolean;

--- a/src/lib/Downloader.ts
+++ b/src/lib/Downloader.ts
@@ -6,7 +6,7 @@ const debug = require('debug')('build:downloader');
 import { DownloaderBase } from './common/DownloaderBase';
 import { mergeOptions } from './util';
 
-interface IDownloaderOptions {
+export interface IDownloaderOptions {
     platform?: string;
     arch?: string;
     version?: string;

--- a/src/lib/FFmpegDownloader.ts
+++ b/src/lib/FFmpegDownloader.ts
@@ -10,7 +10,7 @@ const progress = require('request-progress');
 import { Event, DownloaderBase } from './common';
 import { mergeOptions, extractGeneric } from './util';
 
-interface IRequestProgress {
+export interface IRequestProgress {
     percent: number;
     speed: number;
     size: {
@@ -23,7 +23,7 @@ interface IRequestProgress {
     };
 }
 
-interface IFFmpegDownloaderOptions {
+export interface IFFmpegDownloaderOptions {
     platform?: string;
     arch?: string;
     version?: string;

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -11,7 +11,7 @@ import { FFmpegDownloader } from './FFmpegDownloader';
 import { BuildConfig } from './config';
 import { mergeOptions, findExecutable, findFFmpeg, tmpDir, spawnAsync, extractGeneric } from './util';
 
-interface IRunnerOptions {
+export interface IRunnerOptions {
     x86?: boolean;
     x64?: boolean;
     chromeApp?: boolean;

--- a/src/lib/common/DownloaderBase.ts
+++ b/src/lib/common/DownloaderBase.ts
@@ -14,7 +14,7 @@ import { mergeOptions, extractGeneric } from '../util';
 const DIR_CACHES = resolve(dirname(module.filename), '..', '..', '..', 'caches');
 ensureDirSync(DIR_CACHES);
 
-interface IRequestProgress {
+export interface IRequestProgress {
     percent: number;
     speed: number;
     size: {

--- a/src/lib/common/NsisVersionInfo.ts
+++ b/src/lib/common/NsisVersionInfo.ts
@@ -5,14 +5,14 @@ import { createHash } from 'crypto';
 import { exists, readJson, writeJson, createReadStream } from 'fs-extra';
 import * as semver from 'semver';
 
-interface IInstaller {
+export interface IInstaller {
     arch: string;
     path: string;
     hash: string;
     created: number;
 }
 
-interface IUpdater {
+export interface IUpdater {
     arch: string;
     fromVersion: string;
     path: string;
@@ -20,7 +20,7 @@ interface IUpdater {
     created: number;
 }
 
-interface IVersion {
+export interface IVersion {
     version: string;
     changelog: string;
     source: string;
@@ -28,7 +28,7 @@ interface IVersion {
     updaters: IUpdater[];
 }
 
-interface IVersionInfoData {
+export interface IVersionInfoData {
     latest: string;
     versions: IVersion[];
 }

--- a/src/lib/nsis-gen/index.ts
+++ b/src/lib/nsis-gen/index.ts
@@ -9,7 +9,7 @@ export * from './Nsis7Zipper';
 const DIR_ASSETS = resolve(dirname(module.filename), '../../../assets/');
 const DIR_NSIS = resolve(DIR_ASSETS, 'nsis');
 
-interface INsisBuildOptions {
+export interface INsisBuildOptions {
     mute: boolean;
 }
 

--- a/src/lib/util/archive.ts
+++ b/src/lib/util/archive.ts
@@ -8,7 +8,7 @@ const debug = require('debug')('build:archive');
 
 import { tmpFile, spawnAsync } from './';
 
-interface IExtractOptions {
+export interface IExtractOptions {
     overwrite: boolean;
 }
 


### PR DESCRIPTION
Hey,

I'm using this library from a typescript project, but the way the module is currently distributed makes it impossible to access typescript declarations. I followed the instructions on https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html in order to add declarations to the output of tsc.

I've had to export a few interfaces that previously weren't, as prompted by tsc when run with the `--declaration` flag.

Cheers,
Alex