### PR TITLE
feat(destination): add a destination option to configure cache directory

### DIFF
--- a/src/lib/Builder.ts
+++ b/src/lib/Builder.ts
@@ -13,7 +13,7 @@ const plist = require('plist');
 import { Downloader } from './Downloader';
 import { FFmpegDownloader } from './FFmpegDownloader';
 import { BuildConfig } from './config';
-import { NsisVersionInfo } from './common';
+import { NsisVersionInfo, DownloaderBase } from './common';
 import { NsisComposer, NsisDiffer, Nsis7Zipper, nsisBuild } from './nsis-gen';
 import { mergeOptions, findExecutable, findFFmpeg, findRuntimeRoot, findExcludableDependencies, tmpName, tmpFile, tmpDir, fixWindowsVersion, copyFileAsync, extractGeneric, compress } from './util';
 
@@ -35,6 +35,7 @@ interface IBuilderOptions {
     mirror?: string;
     concurrent?: boolean;
     mute?: boolean;
+    destination?: string;
 }
 
 export class Builder {
@@ -50,6 +51,7 @@ export class Builder {
         mirror: Downloader.DEFAULT_OPTIONS.mirror,
         concurrent: false,
         mute: true,
+        destination: DownloaderBase.DEFAULT_DESTINATION,
     };
 
     public options: IBuilderOptions;
@@ -477,6 +479,7 @@ export class Builder {
             version: config.nwVersion,
             useCaches: true,
             showProgress: this.options.mute ? false : true,
+            destination: this.options.destination,
         });
 
         if(!this.options.mute) {
@@ -764,6 +767,7 @@ export class Builder {
             mirror: this.options.mirror,
             useCaches: true,
             showProgress: this.options.mute ? false : true,
+            destination: this.options.destination,
         });
 
         if(!this.options.mute) {

--- a/src/lib/Downloader.ts
+++ b/src/lib/Downloader.ts
@@ -14,6 +14,7 @@ interface IDownloaderOptions {
     mirror?: string;
     useCaches?: boolean;
     showProgress?: boolean;
+    destination?: string;
 }
 
 export class Downloader extends DownloaderBase {
@@ -26,6 +27,7 @@ export class Downloader extends DownloaderBase {
         mirror: 'https://dl.nwjs.io/',
         useCaches: true,
         showProgress: true,
+        destination: DownloaderBase.DEFAULT_DESTINATION,
     };
 
     public options: IDownloaderOptions;
@@ -34,6 +36,10 @@ export class Downloader extends DownloaderBase {
         super();
 
         this.options = mergeOptions(Downloader.DEFAULT_OPTIONS, options);
+
+        if(this.options.destination !== this.destination) {
+            this.setDestination(this.options.destination);
+        }
 
         if(process.env.NWJS_MIRROR) {
             this.options.mirror = process.env.NWJS_MIRROR;

--- a/src/lib/FFmpegDownloader.ts
+++ b/src/lib/FFmpegDownloader.ts
@@ -30,6 +30,7 @@ interface IFFmpegDownloaderOptions {
     mirror?: string;
     useCaches?: boolean;
     showProgress?: boolean;
+    destination?: string;
 }
 
 export class FFmpegDownloader extends DownloaderBase {
@@ -41,6 +42,7 @@ export class FFmpegDownloader extends DownloaderBase {
         mirror: 'https://github.com/iteufel/nwjs-ffmpeg-prebuilt/releases/download/',
         useCaches: true,
         showProgress: true,
+        destination: DownloaderBase.DEFAULT_DESTINATION,
     };
 
     public options: IFFmpegDownloaderOptions;
@@ -49,6 +51,10 @@ export class FFmpegDownloader extends DownloaderBase {
         super();
 
         this.options = mergeOptions(FFmpegDownloader.DEFAULT_OPTIONS, options);
+
+        if(this.options.destination !== this.destination) {
+            this.setDestination(this.options.destination);
+        }
 
         debug('in constructor', 'options', options);
 

--- a/src/lib/Runner.ts
+++ b/src/lib/Runner.ts
@@ -10,6 +10,7 @@ import { Downloader } from './Downloader';
 import { FFmpegDownloader } from './FFmpegDownloader';
 import { BuildConfig } from './config';
 import { mergeOptions, findExecutable, findFFmpeg, tmpDir, spawnAsync, extractGeneric } from './util';
+import { DownloaderBase } from './common';
 
 interface IRunnerOptions {
     x86?: boolean;
@@ -18,6 +19,7 @@ interface IRunnerOptions {
     mirror?: string;
     detached?: boolean;
     mute?: boolean;
+    destination?: string;
 }
 
 export class Runner {
@@ -29,6 +31,7 @@ export class Runner {
         mirror: Downloader.DEFAULT_OPTIONS.mirror,
         detached: false,
         mute: true,
+        destination: DownloaderBase.DEFAULT_DESTINATION,
     };
 
     public options: IRunnerOptions;
@@ -61,6 +64,7 @@ export class Runner {
             mirror: this.options.mirror,
             useCaches: true,
             showProgress: this.options.mute ? false : true,
+            destination: this.options.destination,
         });
 
         if(!this.options.mute) {
@@ -123,6 +127,7 @@ export class Runner {
             version: config.nwVersion,
             useCaches: true,
             showProgress: this.options.mute ? false : true,
+            destination: this.options.destination,
         });
 
         if(!this.options.mute) {

--- a/src/lib/common/DownloaderBase.ts
+++ b/src/lib/common/DownloaderBase.ts
@@ -31,7 +31,9 @@ export abstract class DownloaderBase {
 
     public onProgress: Event<IRequestProgress> = new Event('progress');
 
-    protected destination: string = DIR_CACHES;
+    public static readonly DEFAULT_DESTINATION: string = DIR_CACHES;
+
+    protected destination: string = DownloaderBase.DEFAULT_DESTINATION;
 
     public abstract async fetch(): Promise<string>;
 


### PR DESCRIPTION
Hey,

See #101.

This PR adds a destination option to Downloader, FFmpegDownloader, Runner and Builder. The default is still set in DownloaderBase.

Cheers,
Alex