### PR TITLE
Added option for prettify package.json

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -17,6 +17,7 @@ files | string[] | Glob patterns for included files. Exclude `${ output }` autom
 excludes | string[] | Glob patterns for excluded files. Defaults to `[]`.
 appId | string | App identity URI. Defaults to `io.github.nwjs.${ name }`.
 ffmpegIntegration | boolean | Whether to integrate `iteufel/nwjs-ffmpeg-prebuilt`. If `true`, you can NOT use symbols in `nwVersion`. Defaults to `false`.
+strippedProperties | string[] | Properties to be stripped from `package.json`. Defaults to `[ 'scripts', 'devDependencies', 'build' ]`.
 prettyPropertiesSpace | string or number | Prettify properties in `package.json`. A number is setups count of spaces, else - specifiied tab symbol. Defaults to `0`.
 
 

--- a/docs/Options.md
+++ b/docs/Options.md
@@ -17,7 +17,8 @@ files | string[] | Glob patterns for included files. Exclude `${ output }` autom
 excludes | string[] | Glob patterns for excluded files. Defaults to `[]`.
 appId | string | App identity URI. Defaults to `io.github.nwjs.${ name }`.
 ffmpegIntegration | boolean | Whether to integrate `iteufel/nwjs-ffmpeg-prebuilt`. If `true`, you can NOT use symbols in `nwVersion`. Defaults to `false`.
-strippedProperties | string[] | Properties to be stripped from `package.json`. Defaults to `[ 'scripts', 'devDependencies', 'build' ]`.
+prettyPropertiesSpace | string or number | Prettify properties in `package.json`. A number is setups count of spaces, else - specifiied tab symbol. Defaults to `0`.
+
 
 ## build.win <- [WinConfig](../src/lib/config/WinConfig.ts)
 

--- a/src/lib/Builder.ts
+++ b/src/lib/Builder.ts
@@ -172,7 +172,7 @@ export class Builder {
             }
         }
 
-        await writeFile(path, JSON.stringify(json));
+        await writeFile(path, JSON.stringify(json, null, config.prettyPropertiesSpace));
 
     }
 

--- a/src/lib/config/BuildConfig.ts
+++ b/src/lib/config/BuildConfig.ts
@@ -26,6 +26,7 @@ export class BuildConfig {
     public appId: string = undefined;
     public ffmpegIntegration: boolean = false;
     public strippedProperties: string[] = [ 'scripts', 'devDependencies', 'build' ];
+    public prettyPropertiesSpace: string | number = 0;
 
     constructor(pkg: any = {}) {
 


### PR DESCRIPTION
In some cases `package.json`should be in pretty view. This Pull Reques add new option for prettify `package.json`. The `JSON.stringify()` method allows setup prettify option like Number or a String ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify)).