### PR TITLE
Added new build.overriddenProperties property

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -18,6 +18,7 @@ excludes | string[] | Glob patterns for excluded files. Defaults to `[]`.
 appId | string | App identity URI. Defaults to `io.github.nwjs.${ name }`.
 ffmpegIntegration | boolean | Whether to integrate `iteufel/nwjs-ffmpeg-prebuilt`. If `true`, you can NOT use symbols in `nwVersion`. Defaults to `false`.
 strippedProperties | string[] | Properties to be stripped from `package.json`. Defaults to `[ 'scripts', 'devDependencies', 'build' ]`.
+overriddenProperties | object | Reassigns the value of a property at the root of the `package.json` with the value given. Example: `"overriddenProperties": { "chromium-args": "--mixed-context" }`. In your build this would replace whatever chromium-args you were using during development. 
 
 ## build.win <- [WinConfig](../src/lib/config/WinConfig.ts)
 

--- a/src/lib/Builder.ts
+++ b/src/lib/Builder.ts
@@ -168,9 +168,8 @@ export class Builder {
 
         for(const key in pkg) {
             if(pkg.hasOwnProperty(key) && config.strippedProperties.indexOf(key) === -1) {
-                //FP
-                if (config.overridenProperties && config.overridenProperties.hasOwnProperty(key) ) {
-                    json[key] = config.overridenProperties[key];
+                if (config.overriddenProperties && config.overriddenProperties.hasOwnProperty(key) ) {
+                    json[key] = config.overriddenProperties[key];
                 } else {
                     json[key] = pkg[key];
                 }

--- a/src/lib/Builder.ts
+++ b/src/lib/Builder.ts
@@ -168,7 +168,12 @@ export class Builder {
 
         for(const key in pkg) {
             if(pkg.hasOwnProperty(key) && config.strippedProperties.indexOf(key) === -1) {
-                json[key] = pkg[key];
+                //FP
+                if (config.overridenProperties && config.overridenProperties.hasOwnProperty(key) ) {
+                    json[key] = config.overridenProperties[key];
+                } else {
+                    json[key] = pkg[key];
+                }
             }
         }
 

--- a/src/lib/config/BuildConfig.ts
+++ b/src/lib/config/BuildConfig.ts
@@ -26,6 +26,7 @@ export class BuildConfig {
     public appId: string = undefined;
     public ffmpegIntegration: boolean = false;
     public strippedProperties: string[] = [ 'scripts', 'devDependencies', 'build' ];
+    public overriddenProperties: any = {};
 
     constructor(pkg: any = {}) {
 


### PR DESCRIPTION

Used when build needs modified property.
example:

"chromium-args": "--mixed-context --load-extension='./node_modules/nw-vue-devtools/extension'"
vs
"chromium-args": "--mixed-context"

We can use many extensions.
Some in both modes but some only in build mode..